### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are using docker, you can install `headscale` alongside `headscale-ui`, l
 version: '3.5'
 services:
   headscale:
-    image: headscale/headscale:latest-alpine
+    image: headscale/headscale:latest
     container_name: headscale
     volumes:
       - ./container-config:/etc/headscale

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -1,50 +1,53 @@
-## Traefik Configuration
-(Thanks @DennisGaida)
+# Traefik Configuration
+
+(Thanks [DennisGaida](https://github.com/DennisGaida) and [Niek](https://github.com/Niek))
+
+Below is a complete docker-compose example for bringing up Traefik + headscale + headscale-ui. Run with: `docker-compose up -d` and headscale-ui will be accessible at <http://localhost/web>.
+
 ```yaml
+version: '3.9'
+
+services:
   headscale:
     image: headscale/headscale:latest
+    pull_policy: always
     container_name: headscale
     restart: unless-stopped
-    networks:
-      - traefik_proxy
     command: headscale serve
     volumes:
-      - $DOCKERDIR/headscale/config:/etc/headscale
+      - ./headscale/config:/etc/headscale
+      - ./headscale/data:/var/lib/headscale
     labels:
-      - "traefik.enable=true"
-      ## HTTP Routers
-      - "traefik.http.routers.headscale-rtr.entrypoints=https"
-      - "traefik.http.routers.headscale-rtr.rule=Host(`hs.${DOMAIN_PUBLIC}`)"
-      ## Middlewares
-      - "traefik.http.routers.headscale-rtr.middlewares=chain-no-auth@file"
-      ## HTTP Services
-      - "traefik.http.routers.headscale-rtr.service=headscale-svc"
-      - "traefik.http.services.headscale-svc.loadbalancer.server.port=8080"
+      - traefik.enable=true
+      - traefik.http.routers.headscale-rtr.rule=PathPrefix(`/`) # you might want to add: && Host(`your.domain.name`)"
+      - traefik.http.services.headscale-svc.loadbalancer.server.port=8080
 
   headscale-ui:
     image: ghcr.io/gurucomputing/headscale-ui:latest
+    pull_policy: always
     container_name: headscale-ui
     restart: unless-stopped
-    networks:
-      - traefik_proxy
     labels:
-      - "traefik.enable=true"
-      ## HTTP Routers
-      - "traefik.http.routers.headscale_ui-rtr.entrypoints=https"
-      - "traefik.http.routers.headscale_ui-rtr.rule=Host(`hs.${DOMAIN_PUBLIC}`) && PathPrefix(`/web`)"
-      ## Middlewares
-      - "traefik.http.routers.headscale_ui-rtr.middlewares=chain-no-auth@file"
-      ## HTTP Services
-      - "traefik.http.routers.headscale_ui-rtr.service=headscale_ui-svc"
-      - "traefik.http.services.headscale_ui-svc.loadbalancer.server.port=443"
-      - "traefik.http.services.headscale_ui-svc.loadbalancer.server.scheme=https"
-      - "traefik.http.services.headscale_ui-svc.loadbalancer.serversTransport=disableSSLCheck@file"
-```
+      - traefik.enable=true
+      - traefik.http.routers.headscale-ui-rtr.rule=PathPrefix(`/web`) # you might want to add: && Host(`your.domain.name`)"
+      - traefik.http.services.headscale-ui-svc.loadbalancer.server.port=80
 
-and `traefik.yaml`
-```yaml
-http:
-  serversTransports:
-    disableSSLCheck:
-      insecureSkipVerify: true
+  traefik:
+    image: traefik:latest
+    pull_policy: always
+    restart: unless-stopped
+    container_name: traefik
+    command:
+      - --api.insecure=true # remove in production
+      - --providers.docker
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --global.sendAnonymousUsage=false
+    ports:
+      - 80:80
+      - 443:443
+      - 8080:8080 # web UI (enabled with api.insecure)
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/certificates:/certificates
 ```


### PR DESCRIPTION
* The `latest-alpine` headscale tag is no longer used/updated, I switched it to the `latest` tag. See also: https://hub.docker.com/r/headscale/headscale/tags?name=latest
* The Traefik example was incomplete and had some strange rules (like non-standard middleware). I simplified and made it to be a complete example.