### PR TITLE
Adding NGINX Proxy Manager and config.yaml changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ services:
       # - 9443:443
 ```
 
-Headscale UI serves on port 443 and uses a self signed cert by default.
+Headscale UI serves on port 443 and uses a self signed cert by default. You will need to add a `config.yaml` file under your `container-config` folder so that `headscale` has all of the required settings declared. An example from the official `headscale` repo is [here](https://github.com/juanfont/headscale/blob/main/config-example.yaml). 
 
 ### Additional Docker Settings
 The docker container lets you set the following settings:

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -79,6 +79,6 @@ Once all three services are running, set up Headscale and Headscale UI _by creat
 3. Advanced: In the text box, add the following to manage the Headscale UI path properly: 
   ```json
     location /web/ {
-      proxy_pass https://132.145.201.160:8443/web/;
+      proxy_pass https://XXX.XXX.XXX.XXXX:port/web/;
   }
   ```

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -51,3 +51,34 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik/certificates:/certificates
 ```
+
+# NGINX Proxy Manager Configuration
+
+If running Headscale and Headscale UI outside of a consolidated docker-compose file (as above), NGINX Proxy Manager is another easy way to run all three. NGINX Proxy Manager is an easy way to run Headscale and Headscale UI behind a reverse proxy that can manager SSL certs automatically. This assumes the following:
+
+1. Headscale is set up on your Docker host (or another location you can route to) per the instructions [here](https://github.com/juanfont/headscale). 
+2. NGINX Proxy Manager is running and you can use it to generate SSL certificates. More information on NGINX Proxy Manager are [here](https://github.com/NginxProxyManager/nginx-proxy-manager).
+
+Use this simplified docker-compose file to run headscale-ui:
+
+```yaml
+version: '3.5'
+services:
+  headscale-ui:
+    image: ghcr.io/gurucomputing/headscale-ui:latest
+    restart: unless-stopped
+    container_name: headscale-ui
+    ports:
+      - 8443:443 # Use the port of your choice, but map it to 443 on the container
+```
+
+Once all three services are running, set up Headscale and Headscale UI _by creating a proxy host_:
+
+1. Details: Enter the FQDN you will be using for Headscale and Headscale UI, and enable Websockets Support and Block Common Exploits. 
+2. SSL: Select or create the SSL certificate you'll be using for the entire FQDN where both will run. Make sure to enable Force SSL, HTTP/2 Support, HSTS and HSTS Subdomains.
+3. Advanced: In the text box, add the following to manage the Headscale UI path properly: 
+  ```json
+    location /web/ {
+      proxy_pass https://132.145.201.160:8443/web/;
+  }
+  ```


### PR DESCRIPTION
Hi - I've been running Headscale and I use NGINX Proxy Manager in my homelab. I added instructions for how I got Headscale and Headscale UI working, as well as a callout in README.md to note a config.yaml file is needed to spin up Headscale. Hope it's helpful!