### PR TITLE
Rename Machine into Node #115

### DIFF
--- a/src/lib/common/apiFunctions.svelte
+++ b/src/lib/common/apiFunctions.svelte
@@ -157,7 +157,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/machine/' + deviceID + '/tags';
+		let endpointURL = '/api/v1/node/' + deviceID + '/tags';
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -250,7 +250,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for getting users
-		let endpointURL = '/api/v1/machine';
+		let endpointURL = '/api/v1/node';
 
 		//returning variables
 		let headscaleDevices = [new Device()];
@@ -281,7 +281,7 @@
 			});
 
 		await headscaleDeviceResponse.json().then((data) => {
-			headscaleDevices = data.machines;
+			headscaleDevices = data.nodes;
 			headscaleDevices = sortDevices(headscaleDevices);
 		});
 		// set the stores
@@ -440,7 +440,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/machine/register';
+		let endpointURL = '/api/v1/node/register';
 
 		await fetch(headscaleURL + endpointURL + '?user=' + userName + '&key=' + key, {
 			method: 'POST',
@@ -469,7 +469,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/machine/' + deviceID + '/user?user=' + user;
+		let endpointURL = '/api/v1/node/' + deviceID + '/user?user=' + user;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -498,7 +498,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/machine/' + deviceID + '/rename/' + name;
+		let endpointURL = '/api/v1/node/' + deviceID + '/rename/' + name;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -527,7 +527,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for removing devices
-		let endpointURL = '/api/v1/machine/' + deviceID;
+		let endpointURL = '/api/v1/node/' + deviceID;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'DELETE',

--- a/src/lib/devices/DeviceCard/DeviceRoutesAPI.svelte
+++ b/src/lib/devices/DeviceCard/DeviceRoutesAPI.svelte
@@ -7,7 +7,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for getting users
-		let endpointURL = '/api/v1/machine/' + deviceID + '/routes';
+		let endpointURL = '/api/v1/node/' + deviceID + '/routes';
 
 		//returning variables
 		let headscaleRouteList: Route[] = [];


### PR DESCRIPTION
Updated all the /machine API endpoints to /node as updated by the headscale creator @juanfont in the https://github.com/gurucomputing/headscale-ui/issues/115 issue. 

Have tested and it is working. I've also created a working nginx and apache hosting setup. Will be updating the readme / steps for configuring nginx / apache as a reverse proxy for the headscale and headscale-ui.