### PR TITLE
change api to dynamically check for breaking change

### DIFF
--- a/documentation/route_queries.md
+++ b/documentation/route_queries.md
@@ -1,0 +1,27 @@
+# Route Queries
+
+Some routes offer additional behavior to a route when a `?` exists in the URL. These are called query string parameters or route queries. Route queries are used to modify the behavior of a route. Below are the available route queries.
+
+## Devices
+
+/devices.html
+
+### Parameters
+
+#### `?nodekey={nodekey of a pending device}`
+
+When this parameter exists, it will automatically open the New Device form and pre-fill the Device Key input automatically. Everything right of the `=` is used as the value of the input.
+
+Below is an example of how to set up a redirect in NGINX from the default headscale /register/{nodekey} URL to utilize this parameter:
+
+```nginx
+    ...
+
+    location /register/nodekey {
+        rewrite ^/register/(.*)$ /web/devices.html?nodekey=$1 redirect;
+    }
+
+    location /web {
+
+    ...
+```

--- a/src/lib/common/Stores.svelte
+++ b/src/lib/common/Stores.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { onMount } from 'svelte';
-	import { deviceSortStore, deviceSortDirectionStore, userSortStore, sortDirectionStore, themeStore, showACLPagesStore } from '$lib/common/stores.js';
+	import { deviceSortStore, deviceSortDirectionStore, userSortStore, sortDirectionStore, themeStore, showACLPagesStore, APIMachineOrNode } from '$lib/common/stores.js';
 	import { URLStore } from '$lib/common/stores.js';
 	import { APIKeyStore } from '$lib/common/stores.js';
 	import { preAuthHideStore } from '$lib/common/stores.js';
@@ -28,6 +28,9 @@
 		URLStore.subscribe((val) => localStorage.setItem('headscaleURL', val.replace(/\/+$/, '')));
 		APIKeyStore.set(localStorage.getItem('headscaleAPIKey') || '');
 		APIKeyStore.subscribe((val) => localStorage.setItem('headscaleAPIKey', val));
+		// stores api version compatibility info
+		APIMachineOrNode.set(localStorage.getItem('headscaleAPIMachineOrNode') || 'machine');
+		APIMachineOrNode.subscribe((val) => localStorage.setItem('headscaleAPIMachineOrNode', val));
 
 		// stores whether preauthkeys get hidden when expired/used
 		preAuthHideStore.set((localStorage.getItem('headscalePreAuthHide') || 'false') == 'true');

--- a/src/lib/common/apiFunctions.svelte
+++ b/src/lib/common/apiFunctions.svelte
@@ -157,7 +157,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/machine/' + deviceID + '/tags';
+		let endpointURL = '/api/v1/node/' + deviceID + '/tags';
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -250,7 +250,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for getting users
-		let endpointURL = '/api/v1/machine';
+		let endpointURL = '/api/v1/node';
 
 		//returning variables
 		let headscaleDevices = [new Device()];
@@ -281,7 +281,7 @@
 			});
 
 		await headscaleDeviceResponse.json().then((data) => {
-			headscaleDevices = data.machines;
+			headscaleDevices = data.nodes;
 			headscaleDevices = sortDevices(headscaleDevices);
 		});
 		// set the stores
@@ -440,7 +440,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/machine/register';
+		let endpointURL = '/api/v1/node/register';
 
 		await fetch(headscaleURL + endpointURL + '?user=' + userName + '&key=' + key, {
 			method: 'POST',
@@ -469,7 +469,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/machine/' + deviceID + '/user?user=' + user;
+		let endpointURL = '/api/v1/node/' + deviceID + '/user?user=' + user;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -498,7 +498,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/machine/' + deviceID + '/rename/' + name;
+		let endpointURL = '/api/v1/node/' + deviceID + '/rename/' + name;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -527,7 +527,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for removing devices
-		let endpointURL = '/api/v1/machine/' + deviceID;
+		let endpointURL = '/api/v1/node/' + deviceID;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'DELETE',

--- a/src/lib/common/apiFunctions.svelte
+++ b/src/lib/common/apiFunctions.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
 	import { APIKey, Device, PreAuthKey, User } from '$lib/common/classes';
-	import { deviceStore, userStore, apiTestStore } from '$lib/common/stores.js';
+	import { deviceStore, userStore, apiTestStore, APIMachineOrNode } from '$lib/common/stores.js';
 	import { sortDevices, sortUsers } from '$lib/common/sorting.svelte';
 	import { filterDevices, filterUsers } from './searching.svelte';
 
@@ -155,9 +155,10 @@
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
+		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/node/' + deviceID + '/tags';
+		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}/${deviceID}/tags`;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -248,9 +249,10 @@
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
+		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
 
 		// endpoint url for getting users
-		let endpointURL = '/api/v1/node';
+		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}`;
 
 		//returning variables
 		let headscaleDevices = [new Device()];
@@ -281,7 +283,7 @@
 			});
 
 		await headscaleDeviceResponse.json().then((data) => {
-			headscaleDevices = data.nodes;
+			headscaleDevices = data[`${headscaleAPIMachineOrNode}s`];
 			headscaleDevices = sortDevices(headscaleDevices);
 		});
 		// set the stores
@@ -438,9 +440,10 @@
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
+		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/node/register';
+		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}/register`;
 
 		await fetch(headscaleURL + endpointURL + '?user=' + userName + '&key=' + key, {
 			method: 'POST',
@@ -467,9 +470,10 @@
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
+		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/node/' + deviceID + '/user?user=' + user;
+		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}/${deviceID}/user?user=${user}`;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -496,9 +500,10 @@
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
+		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
 
 		// endpoint url for editing users
-		let endpointURL = '/api/v1/node/' + deviceID + '/rename/' + name;
+		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}/${deviceID}/rename/${name}`;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'POST',
@@ -525,9 +530,10 @@
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
+		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
 
 		// endpoint url for removing devices
-		let endpointURL = '/api/v1/node/' + deviceID;
+		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}/${deviceID}`;
 
 		await fetch(headscaleURL + endpointURL, {
 			method: 'DELETE',

--- a/src/lib/common/apiFunctions.svelte
+++ b/src/lib/common/apiFunctions.svelte
@@ -40,7 +40,7 @@
 			});
 
 		await headscaleUsersResponse.json().then((data) => {
-			headscaleUsers = data.users
+			headscaleUsers = data.users;
 			// sort the users
 			headscaleUsers = sortUsers(headscaleUsers);
 		});
@@ -152,6 +152,9 @@
 	}
 
 	export async function updateTags(deviceID: string, tags: string[]): Promise<any> {
+		// test the API routes whether we should try to use 'machines' or 'nodes'
+		await testMachineOrNode();
+
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
@@ -245,13 +248,42 @@
 			});
 	}
 
-	export async function getDevices(): Promise<any> {
+	export async function testMachineOrNode() {
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
 
-		// endpoint url for getting users
+		// endpoint url for getting devices
+		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}`;
+		await fetch(headscaleURL + endpointURL, {
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				Authorization: `Bearer ${headscaleAPIKey}`
+			}
+		}).then((response) => {
+			if (!response.ok) {
+				// set APIMachineOrNode to the opposite value
+				if (headscaleAPIMachineOrNode == 'machine') {
+					APIMachineOrNode.set('node');
+				} else {
+					APIMachineOrNode.set('machine');
+				}
+			}
+		});
+	}
+
+	export async function getDevices(): Promise<any> {
+		// test the API routes whether we should try to use 'machines' or 'nodes'
+		await testMachineOrNode();
+
+		// variables in local storage
+		let headscaleURL = localStorage.getItem('headscaleURL') || '';
+		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
+		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
+
+		// endpoint url for getting devices
 		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}`;
 
 		//returning variables
@@ -292,8 +324,6 @@
 		// filter the store
 		filterDevices();
 	}
-
-
 
 	export async function getAPIKeys(): Promise<APIKey[]> {
 		// variables in local storage
@@ -437,6 +467,9 @@
 	}
 
 	export async function newDevice(key: string, userName: string): Promise<any> {
+		// test the API routes whether we should try to use 'machines' or 'nodes'
+		await testMachineOrNode();
+
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
@@ -467,6 +500,9 @@
 	}
 
 	export async function moveDevice(deviceID: string, user: string): Promise<any> {
+		// test the API routes whether we should try to use 'machines' or 'nodes'
+		await testMachineOrNode();
+
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
@@ -497,6 +533,9 @@
 	}
 
 	export async function renameDevice(deviceID: string, name: string): Promise<any> {
+		// test the API routes whether we should try to use 'machines' or 'nodes'
+		await testMachineOrNode();
+
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
@@ -527,6 +566,9 @@
 	}
 
 	export async function removeDevice(deviceID: string): Promise<any> {
+		// test the API routes whether we should try to use 'machines' or 'nodes'
+		await testMachineOrNode();
+		
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';

--- a/src/lib/common/stores.js
+++ b/src/lib/common/stores.js
@@ -10,6 +10,8 @@ export const themeStore = writable('');
 // stores URL and API Key
 export const URLStore = writable('');
 export const APIKeyStore = writable('');
+// stores the type of device api call made for version compatibility
+export const APIMachineOrNode = writable('machine');
 // stores sorting preferences
 export const deviceSortStore = writable('id');
 export const deviceSortDirectionStore = writable('ascending');

--- a/src/lib/devices/CreateDevice.svelte
+++ b/src/lib/devices/CreateDevice.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
-	import { userStore, deviceStore } from '$lib/common/stores';
+	import { userStore } from '$lib/common/stores';
 	import { getDevices, newDevice } from '$lib/common/apiFunctions.svelte';
 	import { alertStore } from '$lib/common/stores.js';
 	import { base } from '$app/paths';
+	import { page } from '$app/stores';
+	import { goto } from "$app/navigation";
 
 	// whether the new card html element is visible
 	export let newDeviceCardVisible = false;
+	export let newDeviceKey = '';
 	let newDeviceForm: HTMLFormElement;
-	let newDeviceKey = '';
 	let selectedUser = '';
 
 	let tabs = ['Default Configuration', 'With Preauth Keys', 'With OIDC'];
@@ -20,8 +22,15 @@
 				.then((response) => {
 					newDeviceCardVisible = false;
 					newDeviceKey = '';
+
 					// refresh devices after editing
 					getDevices();
+
+					// Clear device key in url
+					if ($page.url.searchParams.get('nodekey')) {
+						$page.url.searchParams.delete('nodekey');
+						goto(`?${$page.url.searchParams.toString()}`);
+					}
 				})
 				.catch((error) => {
 					$alertStore = error;

--- a/src/lib/devices/DeviceCard/DeviceRoutesAPI.svelte
+++ b/src/lib/devices/DeviceCard/DeviceRoutesAPI.svelte
@@ -7,7 +7,7 @@
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
 
 		// endpoint url for getting users
-		let endpointURL = '/api/v1/machine/' + deviceID + '/routes';
+		let endpointURL = '/api/v1/node/' + deviceID + '/routes';
 
 		//returning variables
 		let headscaleRouteList: Route[] = [];

--- a/src/lib/devices/DeviceCard/DeviceRoutesAPI.svelte
+++ b/src/lib/devices/DeviceCard/DeviceRoutesAPI.svelte
@@ -1,7 +1,11 @@
 <script context="module" lang="ts">
 	import type { Route } from '$lib/common/classes';
+	import { testMachineOrNode } from '$lib/common/apiFunctions.svelte'
 
 	export async function getDeviceRoutes(deviceID: string): Promise<Route[]> {
+		// test the API routes whether we should try to use 'machines' or 'nodes'
+		await testMachineOrNode();
+
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';

--- a/src/lib/devices/DeviceCard/DeviceRoutesAPI.svelte
+++ b/src/lib/devices/DeviceCard/DeviceRoutesAPI.svelte
@@ -5,9 +5,10 @@
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
+		let headscaleAPIMachineOrNode = localStorage.getItem('headscaleAPIMachineOrNode') || 'machine';
 
 		// endpoint url for getting users
-		let endpointURL = '/api/v1/node/' + deviceID + '/routes';
+		let endpointURL = `/api/v1/${headscaleAPIMachineOrNode}/${deviceID}/routes`;
 
 		//returning variables
 		let headscaleRouteList: Route[] = [];

--- a/src/routes/devices.html/+page.svelte
+++ b/src/routes/devices.html/+page.svelte
@@ -11,9 +11,9 @@
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 
-	let newDeviceKey = $page.url.searchParams.get('nodekey') ?? '';
+	let newDeviceKey = '';
 
-	let newDeviceCardVisible = newDeviceKey.length > 0 ? true : false;
+	let newDeviceCardVisible = false;
 
 	//
 	// Component Variables
@@ -25,6 +25,11 @@
 	// We define the meat of our script in onMount as doing so forces client side rendering.
 	// Doing so also does not perform any actions until components are initialized
 	onMount(async () => {
+
+		// Handle nodekey
+		newDeviceKey = $page.url.searchParams.get('nodekey') ?? ''
+		newDeviceCardVisible = newDeviceKey.length > 0 ? true : false
+
 		// update user list
 		getUsers();
 		// attempt to pull list of devices

--- a/src/routes/devices.html/+page.svelte
+++ b/src/routes/devices.html/+page.svelte
@@ -1,6 +1,7 @@
 <!-- typescript -->
 <script lang="ts">
 	import { base } from '$app/paths';
+	import { page } from '$app/stores';
 	import { getDevices, getUsers } from '$lib/common/apiFunctions.svelte';
 	import { apiTestStore, deviceFilterStore, deviceStore } from '$lib/common/stores.js';
 	import CreateDevice from '$lib/devices/CreateDevice.svelte';
@@ -10,7 +11,9 @@
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 
-	let newDeviceCardVisible = false;
+	let newDeviceKey = $page.url.searchParams.get('nodekey') ?? '';
+
+	let newDeviceCardVisible = newDeviceKey.length > 0 ? true : false;
 
 	//
 	// Component Variables
@@ -54,7 +57,7 @@
 				>
 			</table>
 
-			<CreateDevice bind:newDeviceCardVisible />
+			<CreateDevice bind:newDeviceCardVisible bind:newDeviceKey />
 
 			{#each $deviceStore as device}
 				{#if $deviceFilterStore.includes(device)}


### PR DESCRIPTION
This pull requests checks to see if the api routes for machine have been renamed to node and changes accordingly. Note that this introduces two API calls per device related request instead of one. Due to this, the recommendation is to remove this fix when the old version is deprecated.