### PR TITLE
Update traefic port in configuration.md

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -30,7 +30,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.routers.headscale-ui-rtr.rule=PathPrefix(`/web`) # you might want to add: && Host(`your.domain.name`)"
-      - traefik.http.services.headscale-ui-svc.loadbalancer.server.port=80
+      - traefik.http.services.headscale-ui-svc.loadbalancer.server.port=8080
 
   traefik:
     image: traefik:latest


### PR DESCRIPTION
The latest major release of headscale ui change the default container ports from 80 and 443 to 8080 and 8443. 
Updated the traefik port to reflect changes.