### PR TITLE
fixing unknown command headscale

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -13,7 +13,7 @@ services:
     pull_policy: always
     container_name: headscale
     restart: unless-stopped
-    command: headscale serve
+    command: serve
     volumes:
       - ./headscale/config:/etc/headscale
       - ./headscale/data:/var/lib/headscale


### PR DESCRIPTION
got an error running docker compose:

```
[+] Running 2/2
 ⠿ Container headscale-ui  Created                                                                                                   0.0s
 ⠿ Container headscale     Recreated                                                                                                 0.8s
Attaching to headscale, headscale-ui
headscale     | Error: unknown command "headscale" for "headscale"
headscale     | Run 'headscale --help' for usage.
headscale     | unknown command "headscale" for "headscale"
headscale-ui  | Starting Caddy

```
fixed by removing unnecessary headscale prefix before serve command, followed [headscale docs](https://headscale.net/stable/setup/install/container) 

