### PR TITLE
fix: headscale 25 uses user's "name" instead of "id" to get/create/expire pre-auth keys

### DIFF
--- a/src/lib/common/apiFunctions.svelte
+++ b/src/lib/common/apiFunctions.svelte
@@ -329,7 +329,7 @@
 		return apiKeys;
 	}
 
-	export async function getPreauthKeys(userId: string): Promise<PreAuthKey[]> {
+	export async function getPreauthKeys(userName: string): Promise<PreAuthKey[]> {
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
@@ -341,7 +341,7 @@
 		let headscalePreAuthKey = [new PreAuthKey()];
 		let headscalePreAuthKeyResponse: Response = new Response();
 
-		await fetch(headscaleURL + endpointURL + '?user=' + userId, {
+		await fetch(headscaleURL + endpointURL + '?user=' + userName, {
 			method: 'GET',
 			headers: {
 				Accept: 'application/json',
@@ -367,7 +367,7 @@
 		return headscalePreAuthKey;
 	}
 
-	export async function newPreAuthKey(userId: string, expiry: string, reusable: boolean, ephemeral: boolean): Promise<any> {
+	export async function newPreAuthKey(userName: string, expiry: string, reusable: boolean, ephemeral: boolean): Promise<any> {
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
@@ -381,7 +381,7 @@
 				Authorization: `Bearer ${headscaleAPIKey}`
 			},
 			body: JSON.stringify({
-				user: userId,
+				user: userName,
 				expiration: expiry,
 				reusable: reusable,
 				ephemeral: ephemeral
@@ -401,7 +401,7 @@
 			});
 	}
 
-	export async function removePreAuthKey(userId: string, preAuthKey: string): Promise<any> {
+	export async function removePreAuthKey(userName: string, preAuthKey: string): Promise<any> {
 		// variables in local storage
 		let headscaleURL = localStorage.getItem('headscaleURL') || '';
 		let headscaleAPIKey = localStorage.getItem('headscaleAPIKey') || '';
@@ -416,7 +416,7 @@
 				Authorization: `Bearer ${headscaleAPIKey}`
 			},
 			body: JSON.stringify({
-				user: userId,
+				user: userName,
 				key: preAuthKey
 			})
 		})

--- a/src/lib/users/UserCard/PreAuthKeys.svelte
+++ b/src/lib/users/UserCard/PreAuthKeys.svelte
@@ -10,8 +10,8 @@
 	export let keyList = [new PreAuthKey];
 	let newPreAuthKeyShow = false;
 
-	function expirePreAuthKeyAction(userId: string, preAuthKey: string) {
-		removePreAuthKey(userId, preAuthKey)
+	function expirePreAuthKeyAction(userName: string, preAuthKey: string) {
+		removePreAuthKey(userName, preAuthKey)
 			.then(() => {
 				getPreauthKeysAction();
 			})
@@ -107,7 +107,7 @@
 								<!-- Allow ability to expire if not expired -->
 								{#if new Date(key.expiration).getTime() > new Date().getTime() && (!key.used || key.reusable)}
 								<!-- trash symbol -->
-								<button class="mr-2" on:click={() => {expirePreAuthKeyAction(user.id, key.key)}}
+								<button class="mr-2" on:click={() => {expirePreAuthKeyAction(user.name, key.key)}}
 									><svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 inline flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 										<path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
 									</svg></button

--- a/src/lib/users/UserCard/PreAuthKeys/NewPreAuthKey.svelte
+++ b/src/lib/users/UserCard/PreAuthKeys/NewPreAuthKey.svelte
@@ -15,7 +15,7 @@
 
 	function NewPreAuthKeyAction() {
     let formattedDate = new Date(expiry).toISOString();
-		newPreAuthKey(user.id, formattedDate, reusable, ephemeral)
+		newPreAuthKey(user.name, formattedDate, reusable, ephemeral)
 			.then(() => {
 				newPreAuthKeyShow = false;
 				getPreauthKeysAction();
@@ -26,7 +26,7 @@
 	}
 
   function getPreauthKeysAction() {
-		getPreauthKeys(user.id)
+		getPreauthKeys(user.name)
 			.then((keys) => {
 				keyList = keys;
 			})


### PR DESCRIPTION
I don't know if that's an issue on headscale's side, but they now require the user's name instead of ID for every actions on pre-auth keys

Note: this issue is for compatibility with headscale 25+ and is not backward compatible